### PR TITLE
3주차 fix :  타입단언 부분 수정

### DIFF
--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -34,24 +34,18 @@ function Login() {
         setTouched(prev => ({ ...prev, [field]: true }));
     };
 
-    const validateEmailField = (email: string) => {
+    const validateEmailField = (email: string): FieldStatus => {
         if (!validateEmail(email)) {
-            return {
-                status: "INVALID_FORMAT" as const,
-            };
+            return "INVALID_FORMAT";
         }
-
-        return {
-            status: "AVAILABLE" as const,
-        };
+        return "AVAILABLE";
     };
 
     const fieldHandler: Partial<
         Record<keyof typeof formValue, (valie: string) => void>
     > = {
         email: value => {
-            const { status } = validateEmailField(value);
-            setEmailStatus(status);
+            setEmailStatus(validateEmailField(value));
         },
     };
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/SignUp/Signup.tsx
+++ b/src/pages/SignUp/Signup.tsx
@@ -44,40 +44,29 @@ function Signup() {
         setTouched(prev => ({ ...prev, [field]: true }));
     };
 
-    const validateEmailField = (email: string) => {
+    const validateEmailField = (email: string): FieldStatus => {
         if (!validateEmail(email)) {
-            return {
-                status: "INVALID_FORMAT" as const,
-            };
+            return "INVALID_FORMAT";
         }
-
-        return {
-            status: "NEED_CHECK" as const,
-        };
+        return "NEED_CHECK";
     };
-    const validateNicknameField = (nickName: string) => {
+    const validateNicknameField = (nickName: string): FieldStatus => {
         if (!validateNickname(nickName)) {
-            return {
-                status: "INVALID_FORMAT" as const,
-            };
+            return "INVALID_FORMAT";
         }
-        return {
-            status: "NEED_CHECK" as const,
-        };
+        return "NEED_CHECK";
     };
 
     const fieldHandler: Partial<
         Record<keyof typeof formValue, (value: string) => void>
     > = {
         email: value => {
-            const { status } = validateEmailField(value);
-            setEmailStatus(status);
-            setEmailMessage(EMAIL_MESSAGE[status]);
+            setEmailStatus(validateEmailField(value));
+            setEmailMessage(EMAIL_MESSAGE[validateEmailField(value)]);
         },
         nickname: value => {
-            const { status } = validateNicknameField(value);
-            setNicknameStatus(status);
-            setNicknameMessage(NICKNAME_MESSAGE[status]);
+            setNicknameStatus(validateNicknameField(value));
+            setNicknameMessage(NICKNAME_MESSAGE[validateNicknameField(value)]);
         },
     };
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
- as const를 사용하던 타입 단언 로직 제거
- 객체 + 구조분해 방식 대신, validation 결과를 단일 타입 값으로 반환하도록 리팩토링
- 반환 타입을 명시하여 타입 안정성 강화
- 반환된 값을 그대로 상태에 전달하여 로직 단순화
- 하나의 상태 타입을 기준으로 파생 값을 관리해 일관성 있는 상태 처리 가능